### PR TITLE
Fix  '[soz-core] build errors #317'

### DIFF
--- a/resources/[soz]/soz-core/private/nui/Police/DetectiveBoard.tsx
+++ b/resources/[soz]/soz-core/private/nui/Police/DetectiveBoard.tsx
@@ -1,5 +1,3 @@
-import './DetectiveBoard.scss';
-
 import { FunctionComponent } from 'react';
 
 export const DetectiveBoard: FunctionComponent = () => {

--- a/resources/[soz]/soz-core/private/nui/Police/ScientistCamera.tsx
+++ b/resources/[soz]/soz-core/private/nui/Police/ScientistCamera.tsx
@@ -1,5 +1,3 @@
-import './ScientistCamera.scss';
-
 import { FunctionComponent } from 'react';
 
 export const ScientistCamera: FunctionComponent = () => {


### PR DESCRIPTION
Fixed by removing the imports of the two scss files not present, in `private\nui\Police\ScientistCamera.tsx` and `private\nui\Police\DetectiveBoard.tsx`. 

#317 

![image](https://github.com/SOZ-Faut-etre-Sub/SOZ-FiveM-Server/assets/88200918/8d735e0c-73c3-4fcd-b1f7-8e8e7471d8d1)


