### PR TITLE
Ajouter nom et prénom de la personne qui a réglé une amende - PR pour l'issue #216

### DIFF
--- a/resources/[soz]/soz-bank/server/invoices.lua
+++ b/resources/[soz]/soz-bank/server/invoices.lua
@@ -103,12 +103,12 @@ local function PayInvoice(PlayerData, account, id, marked)
         local messageForEmitter = "Votre facture ~b~%s~s~ a été ~g~payée"
         if invoice.kind == "fine" then
             kindLabel = "amende"
-            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~payée par " .. Player.PlayerData.charinfo.firstname .. " " .. Player.PlayerData.charinfo.lastname
+            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~payée par " .. Player.PlayerData.charinfo.firstname .. " " .. 
+                                    Player.PlayerData.charinfo.lastname
         end
         TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~g~payé~s~ votre " .. kindLabel, "success", 10000)
         if Emitter then
-            TriggerClientEvent("soz-core:client:notification:draw", Emitter.PlayerData.source,
-                               (messageForEmitter):format(invoice.label))
+            TriggerClientEvent("soz-core:client:notification:draw", Emitter.PlayerData.source, (messageForEmitter):format(invoice.label))
         end
 
         exports["soz-core"]:Event("invoice_pay", {
@@ -182,13 +182,13 @@ local function RejectInvoice(PlayerData, account, id)
         local messageForEmitter = "Votre facture ~b~%s~s~ a été ~r~refusée"
         if invoice.kind == "fine" then
             kindLabel = "amende"
-            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~refusée par " .. Player.PlayerData.charinfo.firstname .. " " .. Player.PlayerData.charinfo.lastname
+            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~refusée par " .. Player.PlayerData.charinfo.firstname .. " " .. 
+                                    Player.PlayerData.charinfo.lastname
         end
         TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~r~refusé~s~ votre " .. kindLabel, "error", 10000)
 
         if Emitter then
-            TriggerClientEvent("soz-core:client:notification:draw", Emitter.PlayerData.source,
-                               (messageForEmitter):format(invoice.label))
+            TriggerClientEvent("soz-core:client:notification:draw", Emitter.PlayerData.source, (messageForEmitter):format(invoice.label))
         end
 
         exports["soz-core"]:Event("invoice_refuse", {

--- a/resources/[soz]/soz-bank/server/invoices.lua
+++ b/resources/[soz]/soz-bank/server/invoices.lua
@@ -103,7 +103,7 @@ local function PayInvoice(PlayerData, account, id, marked)
         local messageForEmitter = "Votre facture ~b~%s~s~ a été ~g~payée"
         if invoice.kind == "fine" then
             kindLabel = "amende"
-            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~payée par " .. Player.PlayerData.charinfo.firstname .. " " .. 
+            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~payée par " .. Player.PlayerData.charinfo.firstname .. " " ..
                                     Player.PlayerData.charinfo.lastname
         end
         TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~g~payé~s~ votre " .. kindLabel, "success", 10000)
@@ -182,7 +182,7 @@ local function RejectInvoice(PlayerData, account, id)
         local messageForEmitter = "Votre facture ~b~%s~s~ a été ~r~refusée"
         if invoice.kind == "fine" then
             kindLabel = "amende"
-            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~refusée par " .. Player.PlayerData.charinfo.firstname .. " " .. 
+            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~refusée par " .. Player.PlayerData.charinfo.firstname .. " " ..
                                     Player.PlayerData.charinfo.lastname
         end
         TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~r~refusé~s~ votre " .. kindLabel, "error", 10000)

--- a/resources/[soz]/soz-bank/server/invoices.lua
+++ b/resources/[soz]/soz-bank/server/invoices.lua
@@ -99,10 +99,10 @@ local function PayInvoice(PlayerData, account, id, marked)
         MySQL.update.await("UPDATE invoices SET payed = true WHERE id = ? AND payed = false AND refused = false", {
             invoice.id,
         })
-        local kindLabel = 'facture'
+        local kindLabel = "facture"
         local messageForEmitter = "Votre facture ~b~%s~s~ a été ~g~payée"
-        if invoice.kind == 'fine' then
-            kindLabel = 'amende'
+        if invoice.kind == "fine" then
+            kindLabel = "amende"
             messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~payée par " .. Player.PlayerData.charinfo.firstname .. " " .. Player.PlayerData.charinfo.lastname
         end
         TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~g~payé~s~ votre " .. kindLabel, "success", 10000)
@@ -178,10 +178,10 @@ local function RejectInvoice(PlayerData, account, id)
 
     if PlayerData.charinfo.account == account then
         local Player = QBCore.Functions.GetPlayerByCitizenId(invoice.citizenid)
-        local kindLabel = 'facture'
+        local kindLabel = "facture"
         local messageForEmitter = "Votre facture ~b~%s~s~ a été ~r~refusée"
-        if invoice.kind == 'fine' then
-            kindLabel = 'amende'
+        if invoice.kind == "fine" then
+            kindLabel = "amende"
             messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~refusée par " .. Player.PlayerData.charinfo.firstname .. " " .. Player.PlayerData.charinfo.lastname
         end
         TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~r~refusé~s~ votre " .. kindLabel, "error", 10000)
@@ -345,9 +345,9 @@ RegisterNetEvent("banking:server:sendInvoice", function(target, label, amount, k
 
     if exports["soz-inventory"]:RemoveItem(Player.PlayerData.source, "paper", 1) then
         if CreateInvoice(Player, Target, Player.PlayerData.job.id, Target.PlayerData.charinfo.account, label, tonumber(amount), kind) then
-            local kindLabel = 'facture'
-            if kind == 'fine' then
-                kindLabel = 'amende'
+            local kindLabel = "facture"
+            if kind == "fine" then
+                kindLabel = "amende"
             end
             TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Votre " .. kindLabel .. " a bien été émise")
         end

--- a/resources/[soz]/soz-bank/server/invoices.lua
+++ b/resources/[soz]/soz-bank/server/invoices.lua
@@ -99,11 +99,16 @@ local function PayInvoice(PlayerData, account, id, marked)
         MySQL.update.await("UPDATE invoices SET payed = true WHERE id = ? AND payed = false AND refused = false", {
             invoice.id,
         })
-
-        TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~g~payé~s~ votre facture", "success", 10000)
+        local kindLabel = 'facture'
+        local messageForEmitter = "Votre facture ~b~%s~s~ a été ~g~payée"
+        if invoice.kind == 'fine' then
+            kindLabel = 'amende'
+            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~payée par " .. Player.PlayerData.charinfo.firstname .. " " .. Player.PlayerData.charinfo.lastname
+        end
+        TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~g~payé~s~ votre " .. kindLabel, "success", 10000)
         if Emitter then
             TriggerClientEvent("soz-core:client:notification:draw", Emitter.PlayerData.source,
-                               ("Votre facture ~b~%s~s~ a été ~g~payée"):format(invoice.label))
+                               (messageForEmitter):format(invoice.label))
         end
 
         exports["soz-core"]:Event("invoice_pay", {
@@ -173,11 +178,17 @@ local function RejectInvoice(PlayerData, account, id)
 
     if PlayerData.charinfo.account == account then
         local Player = QBCore.Functions.GetPlayerByCitizenId(invoice.citizenid)
-        TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~r~refusé~s~ votre facture", "error", 10000)
+        local kindLabel = 'facture'
+        local messageForEmitter = "Votre facture ~b~%s~s~ a été ~r~refusée"
+        if invoice.kind == 'fine' then
+            kindLabel = 'amende'
+            messageForEmitter = "Votre amende ~b~%s~s~ a été ~r~refusée par " .. Player.PlayerData.charinfo.firstname .. " " .. Player.PlayerData.charinfo.lastname
+        end
+        TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous avez ~r~refusé~s~ votre " .. kindLabel, "error", 10000)
 
         if Emitter then
             TriggerClientEvent("soz-core:client:notification:draw", Emitter.PlayerData.source,
-                               ("Votre facture ~b~%s~s~ a été ~r~refusée"):format(invoice.label))
+                               (messageForEmitter):format(invoice.label))
         end
 
         exports["soz-core"]:Event("invoice_refuse", {
@@ -334,7 +345,11 @@ RegisterNetEvent("banking:server:sendInvoice", function(target, label, amount, k
 
     if exports["soz-inventory"]:RemoveItem(Player.PlayerData.source, "paper", 1) then
         if CreateInvoice(Player, Target, Player.PlayerData.job.id, Target.PlayerData.charinfo.account, label, tonumber(amount), kind) then
-            TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Votre facture a bien été émise")
+            local kindLabel = 'facture'
+            if kind == 'fine' then
+                kindLabel = 'amende'
+            end
+            TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Votre " .. kindLabel .. " a bien été émise")
         end
     else
         TriggerClientEvent("soz-core:client:notification:draw", Player.PlayerData.source, "Vous n'avez pas de papier", "error")


### PR DESCRIPTION
Je me suis permis de réaliser le dev pour l'issue #216 qui était validée.
En plus de rajouter nom/prénom pour la notif de paiement d'amendes, j'ai aussi remplacé le mot "facture" par "amende" dans toutes les notifs liées aux amendes pour plus de cohérence.