### PR TITLE
[Telephone] Onglet dans l'appli Banque d'historique des mouvements V2 - PR pour l'issue #212

### DIFF
--- a/resources/[soz]/soz-bank/server/main.lua
+++ b/resources/[soz]/soz-bank/server/main.lua
@@ -79,8 +79,7 @@ QBCore.Functions.CreateCallback("banking:server:TransferMoney", function(source,
     local CurrentMoney = Player.Functions.GetMoney("money")
     amount = tonumber(amount)
 
-    
-    if accountSource == "player" then --Dépot
+    if accountSource == "player" then -- Dépot
         if amount <= CurrentMoney then
             if Player.Functions.RemoveMoney("money", amount) then
                 Account.AddMoney(accountTarget, amount)
@@ -96,7 +95,7 @@ QBCore.Functions.CreateCallback("banking:server:TransferMoney", function(source,
                 return
             end
         end
-    elseif accountTarget == "player" then --Retrait
+    elseif accountTarget == "player" then -- Retrait
         local AccountMoney = Account(accountSource).money
         if amount <= AccountMoney then
             if Player.Functions.AddMoney("money", amount) then
@@ -113,7 +112,7 @@ QBCore.Functions.CreateCallback("banking:server:TransferMoney", function(source,
                 return
             end
         end
-    else --Transfert entre 2 comptes
+    else -- Transfert entre 2 comptes
         Account.TransfertMoney(accountSource, accountTarget, amount, function(success, reason)
             if success then
                 exports["soz-core"]:AddBankTransaction(accountSource, accountTarget, amount)
@@ -126,8 +125,7 @@ QBCore.Functions.CreateCallback("banking:server:TransferMoney", function(source,
 
                     if Target then
                         TriggerClientEvent("soz-core:client:notification:draw-advanced", Target.PlayerData.source, "Maze Banque", "Mouvement bancaire",
-                                           "Un versement vient d'être réalisé sur votre compte",
-                                           "CHAR_BANK_MAZE")
+                                           "Un versement vient d'être réalisé sur votre compte", "CHAR_BANK_MAZE")
                     end
                 end
             end

--- a/resources/[soz]/soz-core/prisma/migrations/20240712143059_add_bank_transactions/migration.sql
+++ b/resources/[soz]/soz-core/prisma/migrations/20240712143059_add_bank_transactions/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE `bank_transactions` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `emitterAccount` VARCHAR(50) NOT NULL,
+    `emitterName` VARCHAR(50) NOT NULL,
+    `targetAccount` VARCHAR(50) NOT NULL,
+    `targetName` VARCHAR(50) NOT NULL,
+    `amount` BIGINT NOT NULL DEFAULT 0,
+    `date` TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+
+    INDEX `emitterAccount`(`emitterAccount`),
+    INDEX `targetAccount`(`targetAccount`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/resources/[soz]/soz-core/prisma/schema.prisma
+++ b/resources/[soz]/soz-core/prisma/schema.prisma
@@ -42,6 +42,19 @@ model bank_statements {
   @@index([gangid], map: "gangid")
 }
 
+model bank_transactions {
+  id                 BigInt   @id @default(autoincrement())
+  emitterAccount     String   @db.VarChar(50)
+  emitterName        String   @db.VarChar(50)
+  targetAccount      String   @db.VarChar(50)
+  targetName         String   @db.VarChar(50)
+  amount             BigInt   @default(0)
+  date               DateTime @default(now()) @db.Timestamp(0)
+
+  @@index([emitterAccount], map: "emitterAccount")
+  @@index([targetAccount], map: "targetAccount")
+}
+
 model bans {
   id       Int     @id @default(autoincrement())
   name     String? @db.VarChar(50)

--- a/resources/[soz]/soz-core/src/server/bank/bank.provider.ts
+++ b/resources/[soz]/soz-core/src/server/bank/bank.provider.ts
@@ -11,6 +11,7 @@ import { Notifier } from '../notifier';
 import { JobGradeRepository } from '../repository/job.grade.repository';
 import { ServerStateService } from '../server.state.service';
 import { BankService } from './bank.service';
+import { Exportable } from '@public/core/decorators/exports';
 
 const SENATOR_SALARY = 400;
 
@@ -118,5 +119,10 @@ export class BankProvider {
                 }
             }
         }
+    }
+
+    @Exportable('AddBankTransaction')
+    addBankTransaction(emitterAccount: string, targetAccount: string, amount: number) {
+        this.bankService.addBankTransaction(emitterAccount, targetAccount, amount);
     }
 }

--- a/resources/[soz]/soz-core/src/server/bank/bank.service.ts
+++ b/resources/[soz]/soz-core/src/server/bank/bank.service.ts
@@ -123,6 +123,7 @@ export class BankService {
     private sendTransactionToPhone(transaction: any, player: PlayerData | null) {
         if (player) {
             TriggerClientEvent(ClientEvent.PHONE_APP_BANK_TRANSACTION_CREATED, player.source, {
+                id: Number(transaction.id),
                 emitterAccount: transaction.emitterAccount,
                 emitterName: transaction.emitterName,
                 targetAccount: transaction.targetAccount,

--- a/resources/[soz]/soz-core/src/server/bank/bank.service.ts
+++ b/resources/[soz]/soz-core/src/server/bank/bank.service.ts
@@ -6,7 +6,6 @@ import { PrismaService } from '../database/prisma.service';
 import { ClientEvent } from '@public/shared/event';
 import { PlayerService } from '@public/server/player/player.service';
 import { PlayerData } from '@public/shared/player';
-import { formatISO } from 'date-fns';
 
 @Injectable()
 export class BankService {

--- a/resources/[soz]/soz-core/src/server/player/player.service.ts
+++ b/resources/[soz]/soz-core/src/server/player/player.service.ts
@@ -45,6 +45,16 @@ export class PlayerService {
         return null;
     }
 
+    public getPlayerByBankAccount(bankAccount: string): PlayerData | null {
+        const player = this.QBCore.getPlayerByBankAccount(bankAccount);
+
+        if (player) {
+            return player.PlayerData;
+        }
+
+        return null;
+    }
+
     public getPlayer(source: number): PlayerData | null {
         const player = this.serverStateService.getPlayer(source);
 

--- a/resources/[soz]/soz-core/src/server/qbcore.ts
+++ b/resources/[soz]/soz-core/src/server/qbcore.ts
@@ -48,6 +48,10 @@ export class QBCore {
         return this.QBCore.Functions.GetPlayerByPhone(phone);
     }
 
+    public getPlayerByBankAccount(account: string): QBCorePlayer | null {
+        return this.QBCore.Functions.GetPlayerByBankAccount(account);
+    }
+
     public getPlayer(source: number): QBCorePlayer {
         return this.QBCore.Functions.GetPlayer(source);
     }

--- a/resources/[soz]/soz-core/src/server/vehicle/vehicle.radar.provider.ts
+++ b/resources/[soz]/soz-core/src/server/vehicle/vehicle.radar.provider.ts
@@ -49,7 +49,7 @@ export class VehicleRadarProvider {
         radarID: number,
         vehicleID: number,
         vehicleClass: number,
-        streetName: string
+        streetName: string,
     ) {
         const player = this.playerService.getPlayer(source);
         const radar = await this.radarRepository.find(radarID);
@@ -83,7 +83,7 @@ export class VehicleRadarProvider {
                     RadarMessage.FlashVehicle,
                     radarMessage + '~g~Véhicule autorisé~s~',
                     'CHAR_BLOCKED',
-                    'info'
+                    'info',
                 );
                 return;
             }
@@ -98,7 +98,7 @@ export class VehicleRadarProvider {
                 radarMessage =
                     radarMessage +
                     `Nouveau Record: ~b~${await this.playerService.getNameFromCitizenId(
-                        player.citizenid
+                        player.citizenid,
                     )}~s~ ~o~${vehicleSpeed}km/h~s~~n~`;
 
                 await this.prismaService.radar.update({
@@ -174,10 +174,11 @@ export class VehicleRadarProvider {
                     vehicle_model: vehicleModel,
                     vehicle_type: vehicleType,
                     position: vehiclePosition,
-                }
+                },
             );
 
             this.bankService.transferBankMoney(player.charinfo.account, JobType.Gouv, fine, true);
+            this.bankService.addBankTransaction(player.charinfo.account, JobType.Gouv, fine);
 
             this.notifier.advancedNotify(
                 source,
@@ -185,7 +186,7 @@ export class VehicleRadarProvider {
                 RadarMessage.FlashVehicle,
                 radarMessage,
                 'CHAR_BLOCKED',
-                'info'
+                'info',
             );
 
             this.notifier.advancedNotifyOnDutyWorkers(
@@ -195,7 +196,7 @@ export class VehicleRadarProvider {
                 'CHAR_BLOCKED',
                 'info',
                 FDO,
-                player => {
+                (player) => {
                     const currentVehicle = GetVehiclePedIsIn(GetPlayerPed(player.source), false);
                     if (currentVehicle && RadarInformedVehicle.includes(GetEntityModel(currentVehicle))) {
                         const ped = GetPlayerPed(player.source);
@@ -205,7 +206,7 @@ export class VehicleRadarProvider {
                         );
                     }
                     return false;
-                }
+                },
             );
         }
     }

--- a/resources/[soz]/soz-core/src/shared/event/client.ts
+++ b/resources/[soz]/soz-core/src/shared/event/client.ts
@@ -325,4 +325,5 @@ export enum ClientEvent {
     VANDALISM_UPDATE_PROP = 'soz-core:client:vandalism:update-prop',
 
     ANIMATION_FX = 'soz-core:client:animation:fx',
+    PHONE_APP_BANK_TRANSACTION_CREATED = 'phone:app:bank:transactionCreated',
 }

--- a/resources/[soz]/soz-core/src/shared/event/server.ts
+++ b/resources/[soz]/soz-core/src/shared/event/server.ts
@@ -1,5 +1,6 @@
 export enum ServerEvent {
     PHONE_APP_NEWS_CREATE_BROADCAST = 'phone:app:news:createNewsBroadcast',
+    PHONE_APP_BANK_TRANSACTION_CREATED = 'phone:app:bank:transactionCreated',
 
     ADMIN_RESET_HALLOWEEN = 'soz-core:server:admin:reset-halloween',
     ADMIN_ADD_MONEY = 'soz-core:server:admin:add-money',

--- a/resources/[soz]/soz-phone/src/client/apps/bank.ts
+++ b/resources/[soz]/soz-phone/src/client/apps/bank.ts
@@ -1,8 +1,9 @@
-import { BankEvents } from '../../../typings/app/bank';
+import { BankEvents, BankTransaction } from '../../../typings/app/bank';
 import { sendMessage } from '../../utils/messages';
 import { RegisterNuiProxy } from '../cl_utils';
 
 RegisterNuiProxy(BankEvents.FIVEM_EVENT_FETCH_BALANCE);
+RegisterNuiProxy(BankEvents.FIVEM_EVENT_FETCH_TRANSACTIONS);
 
 onNet(BankEvents.FIVEM_EVENT_UPDATE_BALANCE, async (playerName: string, account: string, balance: number) => {
     sendMessage('BANK', BankEvents.SEND_CREDENTIALS, {
@@ -10,4 +11,8 @@ onNet(BankEvents.FIVEM_EVENT_UPDATE_BALANCE, async (playerName: string, account:
         account: account,
         balance: balance,
     });
+});
+
+onNet(BankEvents.FIVEM_EVENT_TRANSACTION_CREATED, (result: BankTransaction) => {
+    sendMessage('BANK', BankEvents.NEW_TRANSACTION, result);
 });

--- a/resources/[soz]/soz-phone/src/nui/apps/bank/components/BankTransactionCard.tsx
+++ b/resources/[soz]/soz-phone/src/nui/apps/bank/components/BankTransactionCard.tsx
@@ -1,0 +1,91 @@
+import { AppContent } from '@ui/components/AppContent';
+import cn from 'classnames';
+import { FunctionComponent, memo } from 'react';
+import { useSelector } from 'react-redux';
+import { useConfig } from '../../../hooks/usePhone';
+import { RootState } from '../../../store';
+import { BankTransaction } from '@typings/app/bank';
+import { DayAgo } from '@ui/components/DayAgo';
+
+export const BankTransactionCard: FunctionComponent<BankTransaction> = memo(
+    ({ amount, emitterName, targetName, emitterAccount, date }: BankTransaction) => {
+        const config = useConfig();
+
+        const credentials = useSelector((state: RootState) => state.appBank);
+
+        if (!credentials) {
+            return (
+                <AppContent
+                    className={cn('flex justify-center items-center', {
+                        'text-white': config.theme.value === 'dark',
+                        'text-dark': config.theme.value === 'light',
+                    })}
+                >
+                    Information non disponible
+                </AppContent>
+            );
+        }
+
+        const account = credentials.account;
+        const isTransmitter = emitterAccount == account;
+        let operation;
+        let type;
+        let contactName;
+        if (isTransmitter) {
+            operation =
+                '-' +
+                amount.toLocaleString('en-US', {
+                    style: 'currency',
+                    currency: 'USD',
+                    maximumFractionDigits: 0,
+                });
+            type = 'Emission';
+            contactName = targetName;
+        } else {
+            operation =
+                '+' +
+                amount.toLocaleString('en-US', {
+                    style: 'currency',
+                    currency: 'USD',
+                    maximumFractionDigits: 0,
+                });
+            type = 'Réception';
+            contactName = emitterName;
+        }
+
+        return (
+            <li
+                className={cn('w-full my-3 rounded shadow border-l-4', {
+                    'bg-ios-700': config.theme.value === 'dark',
+                    'bg-white': config.theme.value === 'light',
+                })}
+            >
+                <div className={`relative p-3 flex items-center space-x-3`}>
+                    <div className="flex-1 min-w-0">
+                        <p
+                            className={cn('text-left text-sm font-medium', {
+                                'text-gray-100': config.theme.value === 'dark',
+                                'text-gray-700': config.theme.value === 'light',
+                            })}
+                        >
+                            <div className={cn('float-left')}>{contactName}</div>
+                            <div className={cn('float-right')}>
+                                <DayAgo timestamp={date} />
+                            </div>
+                        </p>
+                        <br />
+                        <p
+                            className={cn('text-left text-sm font-medium', {
+                                'text-red-500': isTransmitter,
+                                'text-emerald-500': !isTransmitter,
+                            })}
+                        >
+                            <div className={cn('float-left')}>{type}</div>
+                            <div className={cn('float-right')}>{operation}</div>
+                        </p>
+                    </div>
+                </div>
+            </li>
+        );
+    },
+);

--- a/resources/[soz]/soz-phone/src/nui/apps/bank/index.tsx
+++ b/resources/[soz]/soz-phone/src/nui/apps/bank/index.tsx
@@ -4,15 +4,20 @@ import { Transition } from '@headlessui/react';
 import { AppTitle } from '@ui/components/AppTitle';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
+import { ClockIcon, CurrencyDollarIcon } from '@heroicons/react/outline';
+import { AppContent } from '@ui/components/AppContent';
+import { NavBarButton, NavBarContainer } from '@ui/components/NavBar';
 
 import { AppWrapper } from '../../ui/components/AppWrapper';
 import { useBackground } from '../../ui/hooks/useBackground';
 import { FullPageWithHeader } from '../../ui/layout/FullPageWithHeader';
 import { BankHome } from './pages/BankHome';
+import BankTransactionsList from './pages/BankTransactionsList';
 
 export const BankApp = memo(() => {
     const [t] = useTranslation();
+    const { pathname } = useLocation();
     const backgroundClass = useBackground();
 
     return (
@@ -20,18 +25,27 @@ export const BankApp = memo(() => {
             <Transition
                 appear={true}
                 show={true}
-                enter="transition-all origin-center duration-300"
+                enter="transition-all origin-[20%_90%] duration-300"
                 enterFrom="scale-[0.0] opacity-0"
                 enterTo="scale-100 opacity-100"
-                leave="transition-all origin-center duration-300"
+                leave="transition-all origin-[20%_90%] duration-300"
                 leaveFrom="scale-100 opacity-100"
                 leaveTo="scale-[0.0] opacity-0"
             >
                 <AppWrapper>
-                    <AppTitle title={t('APPS_BANK')} isBigHeader={true} />
+                    <AppTitle title={t('APPS_BANK')} isBigHeader={false} />
                     <Routes>
                         <Route index element={<BankHome />} />
+                        <Route path="history" element={<BankTransactionsList />} />
                     </Routes>
+                    <NavBarContainer nbColumns={2}>
+                        <NavBarButton active={pathname === '/bank'} path={'/bank'}>
+                            <CurrencyDollarIcon className="w-5 h-5" /> {t('BANK.NAVBAR_ACCOUNT')}
+                        </NavBarButton>
+                        <NavBarButton active={pathname === '/bank/history'} path={'/bank/history'}>
+                            <ClockIcon className="w-5 h-5" /> {t('BANK.NAVBAR_HISTORY')}
+                        </NavBarButton>
+                    </NavBarContainer>
                 </AppWrapper>
             </Transition>
         </FullPageWithHeader>

--- a/resources/[soz]/soz-phone/src/nui/apps/bank/pages/BankHome.tsx
+++ b/resources/[soz]/soz-phone/src/nui/apps/bank/pages/BankHome.tsx
@@ -27,7 +27,7 @@ export const BankHome = memo(() => {
     }
 
     return (
-        <AppContent>
+        <AppContent scrollable={false}>
             <div className="m-auto pt-1 pb-3 flex flex-col w-5/6">
                 <h2
                     className={cn('text-3xl', {

--- a/resources/[soz]/soz-phone/src/nui/apps/bank/pages/BankTransactionsList.tsx
+++ b/resources/[soz]/soz-phone/src/nui/apps/bank/pages/BankTransactionsList.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { RootState } from '../../../store';
+import { BankTransactionCard } from '../components/BankTransactionCard';
+import { AppContent } from '@ui/components/AppContent';
+
+const BankTransactionsList = (): any => {
+    const transactionsList = useSelector((state: RootState) => state.appBankTransactions);
+
+    return (
+        <AppContent scrollable={true}>
+            <ul className={`p-2`}>
+                {transactionsList.map(transaction => (
+                    <BankTransactionCard key={transaction.id} {...transaction} />
+                ))}
+            </ul>
+        </AppContent>
+    );
+};
+
+export default BankTransactionsList;

--- a/resources/[soz]/soz-phone/src/nui/apps/bank/utils/constants.ts
+++ b/resources/[soz]/soz-phone/src/nui/apps/bank/utils/constants.ts
@@ -8,6 +8,7 @@ export const MockBankAccountData: IBankCredentials = {
 
 export const MockBankTransactionsData: BankTransaction[] = [
     {
+        id: 1,
         date: 1598400000000,
         amount: BigInt(500),
         emitterName: 'John Doe',
@@ -16,27 +17,12 @@ export const MockBankTransactionsData: BankTransaction[] = [
         targetAccount: 'AAA',
     },
     {
+        id: 2,
         date: 1598600000000,
         amount: BigInt(1500),
         emitterName: '',
         targetName: 'John Doe',
         emitterAccount: 'radar',
         targetAccount: 'BBB',
-    },
-    {
-        date: 1598650000000,
-        amount: BigInt(1500),
-        emitterName: '',
-        targetName: 'John Doe',
-        emitterAccount: 'bank_pacific',
-        targetAccount: 'BBB',
-    },
-    {
-        date: 1598680000000,
-        amount: BigInt(1500),
-        emitterName: 'John Doe',
-        targetName: '',
-        emitterAccount: 'BBB',
-        targetAccount: 'bank_pacific',
     },
 ];

--- a/resources/[soz]/soz-phone/src/nui/apps/bank/utils/constants.ts
+++ b/resources/[soz]/soz-phone/src/nui/apps/bank/utils/constants.ts
@@ -1,7 +1,42 @@
-import { IBankCredentials } from '../../../../../typings/app/bank';
+import { BankTransaction, IBankCredentials } from '../../../../../typings/app/bank';
 
 export const MockBankAccountData: IBankCredentials = {
     name: 'John Doe',
     account: '555Z5555T555',
     balance: 1258745,
 };
+
+export const MockBankTransactionsData: BankTransaction[] = [
+    {
+        date: 1598400000000,
+        amount: BigInt(500),
+        emitterName: 'John Doe',
+        targetName: 'Joe Smith',
+        emitterAccount: 'BBB',
+        targetAccount: 'AAA',
+    },
+    {
+        date: 1598600000000,
+        amount: BigInt(1500),
+        emitterName: '',
+        targetName: 'John Doe',
+        emitterAccount: 'radar',
+        targetAccount: 'BBB',
+    },
+    {
+        date: 1598650000000,
+        amount: BigInt(1500),
+        emitterName: '',
+        targetName: 'John Doe',
+        emitterAccount: 'bank_pacific',
+        targetAccount: 'BBB',
+    },
+    {
+        date: 1598680000000,
+        amount: BigInt(1500),
+        emitterName: 'John Doe',
+        targetName: '',
+        emitterAccount: 'BBB',
+        targetAccount: 'bank_pacific',
+    },
+];

--- a/resources/[soz]/soz-phone/src/nui/locale/fr.json
+++ b/resources/[soz]/soz-phone/src/nui/locale/fr.json
@@ -131,7 +131,9 @@
         },
         "BANK": {
             "HOME_TITLE": "Compte en banque",
-            "CHECKING": "Total :"
+            "CHECKING": "Total :",
+            "NAVBAR_ACCOUNT": "Compte",
+            "NAVBAR_HISTORY": "Historique"
         },
         "MARKETPLACE": {
             "FEEDBACK": {

--- a/resources/[soz]/soz-phone/src/nui/models/app/bank.ts
+++ b/resources/[soz]/soz-phone/src/nui/models/app/bank.ts
@@ -1,5 +1,5 @@
 import { createModel } from '@rematch/core';
-import { BankEvents, IBankCredentials } from '@typings/app/bank';
+import { BankEvents, BankTransaction, IBankCredentials } from '@typings/app/bank';
 
 import { ServerPromiseResp } from '../../../../typings/common';
 import { MockBankAccountData } from '../../apps/bank/utils/constants';
@@ -14,7 +14,7 @@ export const appBank = createModel<RootModel>()({
             return { ...state, ...payload };
         },
     },
-    effects: dispatch => ({
+    effects: (dispatch) => ({
         async setCredentials(payload: IBankCredentials) {
             dispatch.appBank.set(payload);
         },
@@ -22,9 +22,9 @@ export const appBank = createModel<RootModel>()({
             fetchNui<ServerPromiseResp<IBankCredentials>>(
                 BankEvents.FIVEM_EVENT_FETCH_BALANCE,
                 undefined,
-                buildRespObj(MockBankAccountData)
+                buildRespObj(MockBankAccountData),
             )
-                .then(credential => {
+                .then((credential) => {
                     dispatch.appBank.set(credential.data || null);
                 })
                 .catch(() => console.error('Failed to load bank data'));

--- a/resources/[soz]/soz-phone/src/nui/models/app/bankTransactions.ts
+++ b/resources/[soz]/soz-phone/src/nui/models/app/bankTransactions.ts
@@ -1,0 +1,37 @@
+import { createModel } from '@rematch/core';
+
+import { ServerPromiseResp } from '../../../../typings/common';
+import { fetchNui } from '../../utils/fetchNui';
+import { buildRespObj } from '../../utils/misc';
+import { RootModel } from '..';
+import { BankEvents, BankTransaction } from '@typings/app/bank';
+import { MockBankTransactionsData } from '../../apps/bank/utils/constants';
+
+export const appBankTransactions = createModel<RootModel>()({
+    state: [] as BankTransaction[],
+    reducers: {
+        set: (state, payload) => {
+            return [...payload];
+        },
+        add: (state, payload) => {
+            return [payload, ...state];
+        },
+    },
+    effects: (dispatch) => ({
+        async appendTransaction(payload: BankTransaction) {
+            dispatch.appBankTransactions.add(payload);
+        },
+        // loader
+        async loadTransactions() {
+            fetchNui<ServerPromiseResp<BankTransaction[]>>(
+                BankEvents.FIVEM_EVENT_FETCH_TRANSACTIONS,
+                undefined,
+                buildRespObj(MockBankTransactionsData),
+            )
+                .then((transactions) => {
+                    dispatch.appBankTransactions.set(transactions.data.reverse() || []);
+                })
+                .catch(() => console.error('Failed to load transactions'));
+        },
+    }),
+});

--- a/resources/[soz]/soz-phone/src/nui/models/index.ts
+++ b/resources/[soz]/soz-phone/src/nui/models/index.ts
@@ -2,6 +2,7 @@ import { Models } from '@rematch/core';
 
 import { api } from './api';
 import { appBank } from './app/bank';
+import { appBankTransactions } from './app/bankTransactions';
 import { appInvoices } from './app/invoices';
 import { appNotes } from './app/notes';
 import { appSnakeLeaderboard } from './app/snakeLeaderboard';
@@ -32,6 +33,7 @@ export interface RootModel extends Models<RootModel> {
 
     // Apps models
     appBank: typeof appBank;
+    appBankTransactions: typeof appBankTransactions;
     appNotes: typeof appNotes;
     appInvoices: typeof appInvoices;
     appTwitchNews: typeof appTwitchNews;
@@ -50,6 +52,7 @@ export const models: RootModel = {
     avatar,
     photo,
     appBank,
+    appBankTransactions,
     appNotes,
     appInvoices,
     appTwitchNews,

--- a/resources/[soz]/soz-phone/src/nui/services/app/useAppBankService.ts
+++ b/resources/[soz]/soz-phone/src/nui/services/app/useAppBankService.ts
@@ -7,7 +7,9 @@ import { store } from '../../store';
 export const useAppBankService = () => {
     useEffect(() => {
         store.dispatch.appBank.loadCredentials();
+        store.dispatch.appBankTransactions.loadTransactions();
     }, []);
 
     useNuiEvent('BANK', BankEvents.SEND_CREDENTIALS, store.dispatch.appBank.setCredentials);
+    useNuiEvent('BANK', BankEvents.NEW_TRANSACTION, store.dispatch.appBankTransactions.appendTransaction);
 };

--- a/resources/[soz]/soz-phone/src/nui/ui/components/NavBar.tsx
+++ b/resources/[soz]/soz-phone/src/nui/ui/components/NavBar.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import React, { FunctionComponent, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useConfig } from '../../hooks/usePhone';

--- a/resources/[soz]/soz-phone/src/nui/ui/components/NavBar.tsx
+++ b/resources/[soz]/soz-phone/src/nui/ui/components/NavBar.tsx
@@ -4,12 +4,13 @@ import { Link } from 'react-router-dom';
 
 import { useConfig } from '../../hooks/usePhone';
 
-export const NavBarContainer: FunctionComponent<PropsWithChildren> = ({ children }) => {
+
+export const NavBarContainer: FunctionComponent<any> = ({ children, nbColumns = 3 }) => {
     const config = useConfig();
 
     return (
         <div
-            className={cn('absolute -bottom-3.5 inset-x-0 grid grid-cols-3 content-start h-20', {
+            className={cn(`absolute -bottom-3.5 inset-x-0 grid grid-cols-${nbColumns} content-start h-20`, {
                 'bg-ios-700 text-white': config.theme.value === 'dark',
                 'bg-white text-black': config.theme.value === 'light',
             })}

--- a/resources/[soz]/soz-phone/src/server/bank/bank.controller.ts
+++ b/resources/[soz]/soz-phone/src/server/bank/bank.controller.ts
@@ -16,10 +16,3 @@ onNetPromise<string, BankTransaction[]>(BankEvents.FIVEM_EVENT_FETCH_TRANSACTION
         resp({ status: 'error', errorMsg: 'UNKNOWN_ERROR' });
     });
 });
-
-/*onNetPromise<BankTransaction, void>(BankEvents.FIVEM_EVENT_TRANSACTION_CREATED, (reqObj, resp) => {
-    BankService.handleNewTransaction(reqObj, resp).catch((e) => {
-        bankLogger.error(`Error occured in new transaction event (${reqObj.source}), Error:  ${e.message}`);
-        resp({ status: 'error', errorMsg: 'UNKNOWN_ERROR' });
-    });
-});*/

--- a/resources/[soz]/soz-phone/src/server/bank/bank.controller.ts
+++ b/resources/[soz]/soz-phone/src/server/bank/bank.controller.ts
@@ -1,11 +1,25 @@
-import { BankEvents, IBankCredentials } from '../../../typings/app/bank';
+import { BankEvents, BankTransaction, IBankCredentials } from '../../../typings/app/bank';
 import { onNetPromise } from '../lib/PromiseNetEvents/onNetPromise';
 import BankService from './bank.service';
 import { bankLogger } from './bank.utils';
 
 onNetPromise<void, IBankCredentials>(BankEvents.FIVEM_EVENT_FETCH_BALANCE, (reqObj, resp) => {
-    BankService.handleFetchAccount(reqObj, resp).catch(e => {
+    BankService.handleFetchAccount(reqObj, resp).catch((e) => {
         bankLogger.error(`Error occured in fetch bank event (${reqObj.source}), Error:  ${e.message}`);
         resp({ status: 'error', errorMsg: 'UNKNOWN_ERROR' });
     });
 });
+
+onNetPromise<string, BankTransaction[]>(BankEvents.FIVEM_EVENT_FETCH_TRANSACTIONS, (reqObj, resp) => {
+    BankService.handleFetchTransactions(reqObj, resp).catch((e) => {
+        bankLogger.error(`Error occured in fetch transactions event (${reqObj.source}), Error:  ${e.message}`);
+        resp({ status: 'error', errorMsg: 'UNKNOWN_ERROR' });
+    });
+});
+
+/*onNetPromise<BankTransaction, void>(BankEvents.FIVEM_EVENT_TRANSACTION_CREATED, (reqObj, resp) => {
+    BankService.handleNewTransaction(reqObj, resp).catch((e) => {
+        bankLogger.error(`Error occured in new transaction event (${reqObj.source}), Error:  ${e.message}`);
+        resp({ status: 'error', errorMsg: 'UNKNOWN_ERROR' });
+    });
+});*/

--- a/resources/[soz]/soz-phone/src/server/bank/bank.db.ts
+++ b/resources/[soz]/soz-phone/src/server/bank/bank.db.ts
@@ -1,0 +1,18 @@
+import { BankTransaction } from '../../../typings/app/bank';
+
+export class _BankTransactionDB {
+    async getTransactions(account: string): Promise<BankTransaction[]> {
+        var transactions = await exports.oxmysql.query_async(
+            `SELECT emitterAccount, emitterName, targetAccount, targetName, amount, unix_timestamp(date)*1000 as date
+            FROM bank_transactions 
+            WHERE date > date_sub(now(), interval 7 day) 
+                AND (targetAccount = ? OR emitterAccount = ?)
+                AND targetAccount <> emitterAccount`,
+            [account, account],
+        );
+        return transactions;
+    }
+}
+
+const BankTransactionDb = new _BankTransactionDB();
+export default BankTransactionDb;

--- a/resources/[soz]/soz-phone/src/server/bank/bank.db.ts
+++ b/resources/[soz]/soz-phone/src/server/bank/bank.db.ts
@@ -2,7 +2,7 @@ import { BankTransaction } from '../../../typings/app/bank';
 
 export class _BankTransactionDB {
     async getTransactions(account: string): Promise<BankTransaction[]> {
-        var transactions = await exports.oxmysql.query_async(
+        return await exports.oxmysql.query_async(
             `SELECT emitterAccount, emitterName, targetAccount, targetName, amount, unix_timestamp(date)*1000 as date
             FROM bank_transactions 
             WHERE date > date_sub(now(), interval 7 day) 
@@ -10,7 +10,6 @@ export class _BankTransactionDB {
                 AND targetAccount <> emitterAccount`,
             [account, account],
         );
-        return transactions;
     }
 }
 

--- a/resources/[soz]/soz-phone/src/server/bank/bank.db.ts
+++ b/resources/[soz]/soz-phone/src/server/bank/bank.db.ts
@@ -3,7 +3,7 @@ import { BankTransaction } from '../../../typings/app/bank';
 export class _BankTransactionDB {
     async getTransactions(account: string): Promise<BankTransaction[]> {
         return await exports.oxmysql.query_async(
-            `SELECT emitterAccount, emitterName, targetAccount, targetName, amount, unix_timestamp(date)*1000 as date
+            `SELECT id, emitterAccount, emitterName, targetAccount, targetName, amount, unix_timestamp(date)*1000 as date
             FROM bank_transactions 
             WHERE date > date_sub(now(), interval 7 day) 
                 AND (targetAccount = ? OR emitterAccount = ?)

--- a/resources/[soz]/soz-phone/src/server/bank/bank.service.ts
+++ b/resources/[soz]/soz-phone/src/server/bank/bank.service.ts
@@ -1,14 +1,36 @@
-import { IBankCredentials } from '../../../typings/app/bank';
+import { BankEvents, BankTransaction, IBankCredentials } from '../../../typings/app/bank';
 import { PromiseEventResp, PromiseRequest } from '../lib/PromiseNetEvents/promise.types';
 import { bankLogger } from './bank.utils';
+import BankTransactionDB, { _BankTransactionDB } from './bank.db';
 
 class _BankService {
+    private readonly bankTransferDB: _BankTransactionDB;
+
+    constructor() {
+        this.bankTransferDB = BankTransactionDB;
+    }
+
     async handleFetchAccount(reqObj: PromiseRequest<void>, resp: PromiseEventResp<IBankCredentials>) {
         try {
             const account = exports['soz-bank'].GetPlayerAccount(reqObj.source);
             resp({ status: 'ok', data: account });
         } catch (e) {
             bankLogger.error(`Error in handleFetchAccount, ${e.toString()}`);
+            resp({ status: 'error', errorMsg: 'DB_ERROR' });
+        }
+    }
+
+    async handleFetchTransactions(
+        reqObj: PromiseRequest<string>,
+        resp: PromiseEventResp<BankTransaction[]>,
+    ): Promise<void> {
+        try {
+            const account = exports['soz-bank'].GetPlayerAccount(reqObj.source);
+            const transactions = await this.bankTransferDB.getTransactions(account.account);
+
+            resp({ status: 'ok', data: transactions });
+        } catch (e) {
+            bankLogger.error(`Error in handleFetchTransactions, ${e.toString()}`);
             resp({ status: 'error', errorMsg: 'DB_ERROR' });
         }
     }

--- a/resources/[soz]/soz-phone/src/server/bank/bank.service.ts
+++ b/resources/[soz]/soz-phone/src/server/bank/bank.service.ts
@@ -1,4 +1,4 @@
-import { BankEvents, BankTransaction, IBankCredentials } from '../../../typings/app/bank';
+import { BankTransaction, IBankCredentials } from '../../../typings/app/bank';
 import { PromiseEventResp, PromiseRequest } from '../lib/PromiseNetEvents/promise.types';
 import { bankLogger } from './bank.utils';
 import BankTransactionDB, { _BankTransactionDB } from './bank.db';

--- a/resources/[soz]/soz-phone/src/server/players/player.db.ts
+++ b/resources/[soz]/soz-phone/src/server/players/player.db.ts
@@ -6,6 +6,27 @@ export class PlayerRepo {
 
         return result?.citizenid || null;
     }
+
+    async fetchIdentifierFromBankAccount(account: string): Promise<string | null> {
+        const result = await exports.oxmysql.single_async(`SELECT citizenid FROM player WHERE charinfo LIKE ?`, [
+            '%"account":"' + account + '"%',
+        ]);
+
+        return result?.citizenid || null;
+    }
+
+    async fetchNameFromBankAccount(account: string): Promise<string> {
+        const charinfos = await exports.oxmysql.query_async(
+            'SELECT charinfo FROM player WHERE charinfo LIKE ? LIMIT 1',
+            ['%"account":"' + account + '"%']
+        );
+        if (charinfos.length > 0) {
+            const charinfo = JSON.parse(charinfos[0].charinfo);
+            return `${charinfo.firstname} ${charinfo.lastname}`;
+        } else {
+            return account;
+        }
+    }
 }
 
 export default new PlayerRepo();

--- a/resources/[soz]/soz-phone/src/server/players/player.service.ts
+++ b/resources/[soz]/soz-phone/src/server/players/player.service.ts
@@ -83,9 +83,9 @@ class _PlayerService {
         if (fetch) {
             const fetchResult: string | null = await this.playerDB
                 .fetchIdentifierFromPhoneNumber(phoneNumber)
-                .catch(e => {
+                .catch((e) => {
                     playerLogger.error(
-                        `Failed to fetch identifier from phone number for ${phoneNumber}, error: ${e.message}`
+                        `Failed to fetch identifier from phone number for ${phoneNumber}, error: ${e.message}`,
                     );
                     return null;
                 });
@@ -238,6 +238,24 @@ class _PlayerService {
     async handleUnloadPlayerEvent(src: number) {
         this.deletePlayerFromMaps(src);
         emitNet(PhoneEvents.SET_PLAYER_LOADED, src, false);
+    }
+
+    /**
+     * Return the attached identifier for a given account
+     * @param account The account to return identifier for
+     **/
+    async getIdentifierByBankAccount(account: string): Promise<string | null> {
+        // Whether we fetch from database if not found in online players
+        return await this.playerDB.fetchIdentifierFromBankAccount(account);
+    }
+
+    /**
+     * Return the character name for a given account
+     * @param account The account to return name for
+     **/
+    async getNameFromBankAccount(account: string): Promise<string | null> {
+        // Whether we fetch from database if not found in online players
+        return await this.playerDB.fetchNameFromBankAccount(account);
     }
 }
 

--- a/resources/[soz]/soz-phone/typings/app/bank.ts
+++ b/resources/[soz]/soz-phone/typings/app/bank.ts
@@ -4,6 +4,7 @@ export interface IBankCredentials {
     balance: number;
 }
 export interface BankTransaction {
+    id: number,
     amount: bigint;
     emitterAccount: string;
     targetAccount: string;

--- a/resources/[soz]/soz-phone/typings/app/bank.ts
+++ b/resources/[soz]/soz-phone/typings/app/bank.ts
@@ -3,10 +3,21 @@ export interface IBankCredentials {
     account: string;
     balance: number;
 }
+export interface BankTransaction {
+    amount: bigint;
+    emitterAccount: string;
+    targetAccount: string;
+    emitterName: string;
+    targetName: string;
+    date: number;
+}
 
 export enum BankEvents {
     FIVEM_EVENT_FETCH_BALANCE = 'phone:app:bank:fetchBalance',
     FIVEM_EVENT_UPDATE_BALANCE = 'phone:client:app:bank:updateBalance',
     GET_CREDENTIALS = 'phone:app:bank:getAccountData',
     SEND_CREDENTIALS = 'phone:app:bank:sendAccountData',
+    FIVEM_EVENT_FETCH_TRANSACTIONS = 'phone:app:bank:fetchTransactions',
+    FIVEM_EVENT_TRANSACTION_CREATED = 'phone:app:bank:transactionCreated',
+    NEW_TRANSACTION = 'phone:app:bank:addTransaction',
 }


### PR DESCRIPTION
Bonjour !
Je me suis permis de remettre au goût du jour la PR #215 concernant l'issue #212
J'ai repris le code de Maskowh comme base et fait quelques modifications/améliorations.

Dorénavant, l'onglet comprendra, en plus des transferts d'argent entre les joueurs, les dépôts et retraits, ainsi que les flash de radars qui prennent directement sur le compte. 
Les salaires n'ont pas été volontairement mis pour ne pas flood le contenu de l'onglet.
L'onglet affiche par défaut les mouvements des 7 derniers jours.

Je me tiens à disposition s'il y a le moindre retour.

Exemple du rendu visuel : 
![image](https://github.com/user-attachments/assets/a8c570e0-bd46-48ec-a816-41c51a4e57d2)
