### PR TITLE
Ajout des rues environnantes dans les sms de position - PR pour l'issue #256

### DIFF
--- a/resources/[soz]/soz-phone/src/client/cl_messages.ts
+++ b/resources/[soz]/soz-phone/src/client/cl_messages.ts
@@ -29,17 +29,27 @@ RegisterNuiCB<void>(MessageEvents.DELETE_WAYPOINT, async (any, cb) => {
 });
 
 RegisterNuiCB<void>(MessageEvents.GET_POSITION, async (position: any, cb) => {
-    const [posX, posY] = GetEntityCoords(PlayerPedId(), true);
-    cb({ data: { x: posX, y: posY } });
+    const [posX, posY, posZ] = GetEntityCoords(PlayerPedId(), true);
+    cb({ data: { x: posX, y: posY, z: posZ } });
 });
 
 RegisterNuiCB<void>(MessageEvents.GET_DESTINATION, async (position: any, cb) => {
-    const [posX, posY] = GetBlipInfoIdCoord(GetFirstBlipInfoId(8));
-    cb({ data: { x: posX, y: posY } });
+    const [posX, posY, posZ] = GetBlipInfoIdCoord(GetFirstBlipInfoId(8));
+    cb({ data: { x: posX, y: posY, z: posZ } });
 });
 
 RegisterNuiCB<void>(SocietyEvents.SEND_CLIENT_POLICE_NOTIFICATION, async (message: any, cb) => {
     cb(exports['soz-core'].SendPoliceNotification(message));
+});
+
+RegisterNuiCB<void>(MessageEvents.GET_STREET_NAME, async (position: any, cb) => {
+    const [streetA, streetB] = GetStreetNameAtCoord(Number(position.x), Number(position.y), Number(position.z));
+    var street = `${GetStreetNameFromHashKey(streetA)}`;
+
+    if (streetB && streetA !== streetB) {
+        street += ` & ${GetStreetNameFromHashKey(streetB)}`;
+    }
+    cb({ data: street });
 });
 
 onNet(MessageEvents.SEND_MESSAGE_SUCCESS, (messageDto: PreDBMessage) => {

--- a/resources/[soz]/soz-phone/src/nui/apps/messages/components/modal/MessageImageModal.tsx
+++ b/resources/[soz]/soz-phone/src/nui/apps/messages/components/modal/MessageImageModal.tsx
@@ -61,7 +61,7 @@ export const MessageImageModal = ({ isOpen, messageGroupId, onClose, image }: IP
                                 fetchNui<ServerPromiseResp<any>>(MessageEvents.GET_POSITION, {}).then(resp => {
                                     sendMessage({
                                         conversationId: messageGroupId,
-                                        message: `vec2(${resp.data.x},${resp.data.y})`,
+                                        message: `vec3(${resp.data.x},${resp.data.y},${resp.data.z})`,
                                     });
                                     onClose();
                                 });
@@ -78,7 +78,7 @@ export const MessageImageModal = ({ isOpen, messageGroupId, onClose, image }: IP
                                     if (resp.data.x !== 0 && resp.data.y !== 0) {
                                         sendMessage({
                                             conversationId: messageGroupId,
-                                            message: `vec2(${resp.data.x},${resp.data.y})`,
+                                            message: `vec3(${resp.data.x},${resp.data.y},${resp.data.z})`,
                                         });
                                         onClose();
                                     } else {

--- a/resources/[soz]/soz-phone/typings/messages.ts
+++ b/resources/[soz]/soz-phone/typings/messages.ts
@@ -102,4 +102,5 @@ export enum MessageEvents {
     SET_WAYPOINT = 'phone:setWaypoint',
     DELETE_WAYPOINT = 'phone:deleteWaypoint',
     SET_CONVERSATION_ARCHIVED = 'phone:setConversationArchived',
+    GET_STREET_NAME = 'phone:getStreetName',
 }


### PR DESCRIPTION
Bonjour !
Vu que l'issue #256 était validée et qu'aucune PR n'a été faite depuis, je me suis permis de la faire.
Je me suis basé sur le code de fowlerztwitch que j'ai corrigé/finalisé.

J'ai fait le choix de changer le stockage des coordonnées dans les SMS, en passant par des Vecteur3 au lieu de Vecteur2, afin de permettre la récupération des rues environnantes sans calcul hasardeux de la coordonnée en Z. 
La compatibilité avec l'ancien format est assurée pour ne rien casser (ça affiche Destination comme avant).

Je suis évidemment preneur de tout retour.

Le rendu : 
![image](https://github.com/user-attachments/assets/4fd5679a-eaf2-4217-ba66-8e1e026bd463)
