### PR TITLE
[Fouille] Notifier la personne de ce qui lui est pris lors d'une fouille - PR pour l'issue #218

### DIFF
--- a/resources/[soz]/soz-inventory/server/events.lua
+++ b/resources/[soz]/soz-inventory/server/events.lua
@@ -56,7 +56,7 @@ RegisterServerEvent("inventory:server:bin-vandalism", function(invID, ctx)
 end)
 
 QBCore.Functions.CreateCallback("inventory:server:TransfertItem",
-                                function(source, cb, inventorySource, inventoryTarget, item, amount, metadata, slot, targetSlot, manualFilter)
+                                function(source, cb, inventorySource, inventoryTarget, item, amount, metadata, slot, targetSlot, manualFilter, inverse)
     Inventory.TransfertItem(source, inventorySource, inventoryTarget, item, amount, metadata, slot, function(success, reason)
         local sourceInv = Inventory(inventorySource)
         local targetInv = Inventory(inventoryTarget)
@@ -72,7 +72,7 @@ QBCore.Functions.CreateCallback("inventory:server:TransfertItem",
                     coord1.z,
                 });
             end
-            if sourceInv.id ~= targetInv.id then
+            if sourceInv.id ~= targetInv.id and tonumber(source) ~= tonumber(sourceInv.id) then
                 TriggerClientEvent("soz-core:client:notification:draw", sourceInv.id,
                                    string.format("On vous a pris ~r~%s %s", amount, QBCore.Shared.Items[item].label))
             end

--- a/resources/[soz]/soz-inventory/server/events.lua
+++ b/resources/[soz]/soz-inventory/server/events.lua
@@ -73,7 +73,7 @@ QBCore.Functions.CreateCallback("inventory:server:TransfertItem",
                 });
             end
             TriggerClientEvent("soz-core:client:notification:draw", sourceInv.id,
-                                string.format("On vous a pris ~r~%s %s", amount, QBCore.Shared.Items[item].label))
+                               string.format("On vous a pris ~r~%s %s", amount, QBCore.Shared.Items[item].label))
         end
 
         local sourceInventory = sourceInv

--- a/resources/[soz]/soz-inventory/server/events.lua
+++ b/resources/[soz]/soz-inventory/server/events.lua
@@ -56,7 +56,7 @@ RegisterServerEvent("inventory:server:bin-vandalism", function(invID, ctx)
 end)
 
 QBCore.Functions.CreateCallback("inventory:server:TransfertItem",
-                                function(source, cb, inventorySource, inventoryTarget, item, amount, metadata, slot, targetSlot, manualFilter, inverse)
+                                function(source, cb, inventorySource, inventoryTarget, item, amount, metadata, slot, targetSlot, manualFilter)
     Inventory.TransfertItem(source, inventorySource, inventoryTarget, item, amount, metadata, slot, function(success, reason)
         local sourceInv = Inventory(inventorySource)
         local targetInv = Inventory(inventoryTarget)

--- a/resources/[soz]/soz-inventory/server/events.lua
+++ b/resources/[soz]/soz-inventory/server/events.lua
@@ -66,14 +66,16 @@ QBCore.Functions.CreateCallback("inventory:server:TransfertItem",
             local coord2 = GetEntityCoords(GetPlayerPed(targetInv.id))
 
             if (#(coord1 - coord2) > 10) then
-                exports["soz-core"]:Report(source, "Vol de d'objet", targetInv.owner, item .. " " .. amount, {
+                exports["soz-core"]:Report(source, "Vol de l'objet", targetInv.owner, item .. " " .. amount, {
                     coord1.x,
                     coord1.y,
                     coord1.z,
                 });
             end
-            TriggerClientEvent("soz-core:client:notification:draw", sourceInv.id,
+            if sourceInv.id ~= targetInv.id then
+                TriggerClientEvent("soz-core:client:notification:draw", sourceInv.id,
                                 string.format("On vous a pris ~r~%s %s", amount, QBCore.Shared.Items[item].label))
+            end
         end
 
         local sourceInventory = sourceInv

--- a/resources/[soz]/soz-inventory/server/events.lua
+++ b/resources/[soz]/soz-inventory/server/events.lua
@@ -72,6 +72,7 @@ QBCore.Functions.CreateCallback("inventory:server:TransfertItem",
                     coord1.z,
                 });
             end
+            TriggerClientEvent("soz-core:client:notification:draw", sourceInv.id, string.format("On vous a pris ~r~%s %s", amount, QBCore.Shared.Items[item].label))
         end
 
         local sourceInventory = sourceInv

--- a/resources/[soz]/soz-inventory/server/events.lua
+++ b/resources/[soz]/soz-inventory/server/events.lua
@@ -72,7 +72,8 @@ QBCore.Functions.CreateCallback("inventory:server:TransfertItem",
                     coord1.z,
                 });
             end
-            TriggerClientEvent("soz-core:client:notification:draw", sourceInv.id, string.format("On vous a pris ~r~%s %s", amount, QBCore.Shared.Items[item].label))
+            TriggerClientEvent("soz-core:client:notification:draw", sourceInv.id,
+                                string.format("On vous a pris ~r~%s %s", amount, QBCore.Shared.Items[item].label))
         end
 
         local sourceInventory = sourceInv


### PR DESCRIPTION
Bonjour !
Vu que je n'ai pas trouvé de PR pour l'issue #218 validée, la voici !

Je suis resté simple sur le rendu, une notif de type info notifiant la quantité et l'item retiré, en rouge (similaire a la notification quand on se fait prendre de l'argent).
Valable pour une fouille FDO (menotté ou non), mais aussi théoriquement fonctionnel avec la fouille crimi sur personne zipée.

J'ai volontairement mis la notification sans condition de distance entre les 2 joueurs pour qu'elle s'affiche dans tous les cas, et potentiellement permettre aux joueurs victime de cheater de ticket derrière (je l'ai déjà vécu avec de l'argent, donc je me dis que d'autres auront le même réflexe !)

Je suis comme toujours preneur s'il y a le moindre retour.

![image](https://github.com/user-attachments/assets/0ea382f0-f13a-49a0-be5f-faf772c5574b)
![image](https://github.com/user-attachments/assets/177fa1a4-49b7-432a-9cdc-512371edb49c)

