### PR TITLE
feat(phone): support custom audio URLs for ringtones & notifications

### DIFF
--- a/resources/[soz]/soz-core/src/nui/components/Phone/apps/settings/pages/SettingsHome.tsx
+++ b/resources/[soz]/soz-core/src/nui/components/Phone/apps/settings/pages/SettingsHome.tsx
@@ -99,7 +99,7 @@ export const SettingsHome = () => {
     );
     const mappedSocietyNotifications = notiSoundOptions.map(
         MapAudioSettingItem(
-            config.notiSound,
+            config.societyNotification,
             (val: SettingOption) => handleSettingChange('societyNotification', val),
             'notifications'
         )
@@ -202,6 +202,7 @@ export const SettingsHome = () => {
                         </List>
                     </>
                 )}
+
                 <List>
                     <SettingItem
                         label={t('SETTINGS.OPTIONS.RINGTONE')}
@@ -211,6 +212,16 @@ export const SettingsHome = () => {
                         icon={<VolumeUpIcon />}
                         color="bg-[#ee1039]"
                     />
+
+                    {config.ringtone.value === 'custom' && (
+                        <input
+                            className="w-full px-3 py-2 text-sm bg-black/20 rounded-md outline-none"
+                            placeholder="URL de sonnerie .mp3 / .ogg / .wav"
+                            value={config.customRingtoneUrl || ''}
+                            onChange={e => handleSettingChange('customRingtoneUrl', e.target.value)}
+                        />
+                    )}
+
                     <SettingItemSlider
                         label={t('SETTINGS.OPTIONS.RINGTONE_VOLUME')}
                         iconStart={<VolumeOffIcon />}
@@ -219,6 +230,7 @@ export const SettingsHome = () => {
                         onCommit={e => handleSettingChange('ringtoneVol', parseInt(e.target.value))}
                     />
                 </List>
+
                 <List>
                     <SettingItem
                         label={t('SETTINGS.OPTIONS.NOTIFICATION')}
@@ -228,6 +240,16 @@ export const SettingsHome = () => {
                         icon={<BellIcon />}
                         color="bg-[#EA4E3D]"
                     />
+
+                    {config.notiSound.value === 'custom' && (
+                        <input
+                            className="w-full px-3 py-2 text-sm bg-black/20 rounded-md outline-none"
+                            placeholder="URL de notification .mp3 / .ogg / .wav"
+                            value={config.customNotificationUrl || ''}
+                            onChange={e => handleSettingChange('customNotificationUrl', e.target.value)}
+                        />
+                    )}
+
                     <SettingItemSlider
                         label={t('SETTINGS.OPTIONS.NOTIFICATION_VOLUME')}
                         iconStart={<VolumeOffIcon />}
@@ -236,6 +258,7 @@ export const SettingsHome = () => {
                         onCommit={e => handleSettingChange('notiSoundVol', parseInt(e.target.value))}
                     />
                 </List>
+
                 <List>
                     <SettingItem
                         label={t('SETTINGS.OPTIONS.SOCIETY_NOTIFICATION')}
@@ -245,6 +268,16 @@ export const SettingsHome = () => {
                         icon={<BellIcon />}
                         color="bg-[#3d71ea]"
                     />
+
+                    {config.societyNotification.value === 'custom' && (
+                        <input
+                            className="w-full px-3 py-2 text-sm bg-black/20 rounded-md outline-none"
+                            placeholder="URL notification répondeur .mp3 / .ogg / .wav"
+                            value={config.customSocietyNotificationUrl || ''}
+                            onChange={e => handleSettingChange('customSocietyNotificationUrl', e.target.value)}
+                        />
+                    )}
+
                     <SettingItemSlider
                         label={t('SETTINGS.OPTIONS.NOTIFICATION_VOLUME')}
                         iconStart={<VolumeOffIcon />}
@@ -253,6 +286,11 @@ export const SettingsHome = () => {
                         onCommit={e => handleSettingChange('societyNotificationVol', parseInt(e.target.value))}
                     />
                 </List>
+
+
+
+
+
                 <List>
                     <SettingItem
                         label={t('SETTINGS.OPTIONS.THEME')}

--- a/resources/[soz]/soz-core/src/nui/components/Phone/system/config/config.constant.ts
+++ b/resources/[soz]/soz-core/src/nui/components/Phone/system/config/config.constant.ts
@@ -173,6 +173,10 @@ export const notiSoundOptions = [
         label: 'UwU',
         value: 'uwu',
     },
+    {
+    label: 'Personnalisée',
+    value: 'custom',
+    },
 ];
 
 export const ringtoneOptions = [
@@ -195,6 +199,10 @@ export const ringtoneOptions = [
     {
         label: 'Thriller',
         value: 'thriller',
+    },
+    {
+    label: 'Personnalisée',
+    value: 'custom',
     },
 ];
 

--- a/resources/[soz]/soz-core/src/nui/components/Phone/system/config/default.constant.ts
+++ b/resources/[soz]/soz-core/src/nui/components/Phone/system/config/default.constant.ts
@@ -42,6 +42,9 @@ export const defaultConfig = {
     societyNotificationVol: 50,
     handsFree: false,
     planeMode: false,
+    customRingtoneUrl: '',
+    customNotificationUrl: '',
+    customSocietyNotificationUrl: '',
     dynamicAlert: false,
     dynamicAlertVol: 50,
     dynamicAlertDuration: {

--- a/resources/[soz]/soz-core/src/nui/components/Phone/system/sound/hooks/useSound.ts
+++ b/resources/[soz]/soz-core/src/nui/components/Phone/system/sound/hooks/useSound.ts
@@ -74,10 +74,25 @@ export const useSoundSettings = (type: 'ringtone' | 'notiSound' | 'societyNotifi
     const settings = useConfig();
 
     const audioFolder = type === 'ringtone' ? 'ringtones' : 'notifications';
-    const audioFile = type === 'dynamicAlert' ? settings['societyNotification'].value : settings[type].value;
+    const audioFile = type === 'dynamicAlert' ? settings.societyNotification.value : settings[type].value;
+
+    const customRingtoneUrl = settings.customRingtoneUrl?.trim();
+    const customNotificationUrl = settings.customNotificationUrl?.trim();
+    const customSocietyNotificationUrl = settings.customSocietyNotificationUrl?.trim();
+
+    const sound =
+        type === 'ringtone' && settings.ringtone.value === 'custom' && customRingtoneUrl
+            ? customRingtoneUrl
+            : type === 'notiSound' && settings.notiSound.value === 'custom' && customNotificationUrl
+              ? customNotificationUrl
+              : (type === 'societyNotification' || type === 'dynamicAlert') &&
+                  settings.societyNotification.value === 'custom' &&
+                  customSocietyNotificationUrl
+                ? customSocietyNotificationUrl
+                : getPath(`audio/phone/${audioFolder}/${audioFile}.mp3`);
 
     return {
-        sound: getPath(`audio/phone/${audioFolder}/${audioFile}.mp3`),
+        sound,
         volume: settings.planeMode ? 0 : settings[`${type}Vol`] / 100,
     };
 };

--- a/resources/[soz]/soz-core/src/shared/phone/config.ts
+++ b/resources/[soz]/soz-core/src/shared/phone/config.ts
@@ -10,6 +10,9 @@ export type PhoneConfig = {
     ringtone: SettingOption<string>;
     notiSound: SettingOption<string>;
     societyNotification: SettingOption<string>;
+    customRingtoneUrl: string;
+    customNotificationUrl: string;
+    customSocietyNotificationUrl: string;
     ringtoneVol: number;
     notiSoundVol: number;
     societyNotificationVol: number;


### PR DESCRIPTION
- Add support for custom ringtones & notifications URLs
- Allow players to use external audio files as phone ringtones
- Save custom ringtone preferences
- .mp3 || .ogg || .wav supported, no other link (such as youtube) allowed. 