### PR TITLE
feat(animations): add player animation copy

### DIFF
--- a/resources/[soz]/soz-core/src/client/animation/animation.service.ts
+++ b/resources/[soz]/soz-core/src/client/animation/animation.service.ts
@@ -2,8 +2,15 @@ import { Inject, Injectable } from '@core/decorators/injectable';
 import { wait, waitUntil } from '@core/utils';
 import { AnimationFactory, AnimationRunner } from '@public/client/animation/animation.factory';
 import { ServerEvent } from '@public/shared/event';
-
-import { Animation, AnimationStopReason, PlayOptions, Scenario, Walking } from '../../shared/animation';
+import {
+    Animation,
+    AnimationStopReason,
+    CopyableAnimation,
+    PLAYER_COPYABLE_ANIMATION_STATE_KEY,
+    PlayOptions,
+    Scenario,
+    Walking,
+} from '../../shared/animation';
 import { BoxZone } from '../../shared/polyzone/box.zone';
 import { Vector3, Vector4 } from '../../shared/polyzone/vector';
 import { PlayerService } from '../player/player.service';
@@ -25,6 +32,25 @@ export class AnimationService {
     private runningAnimations: Map<string, AnimationStored> = new Map();
     private runningWalking = '';
     private previousWalking = '';
+    private copyableAnimationRunnerId: number | null = null;
+
+    private publishCopyableAnimation(animation: CopyableAnimation, runner: AnimationRunner, ped: number) {
+        if (ped !== PlayerPedId()) {
+            return;
+        }
+
+        this.copyableAnimationRunnerId = runner.id;
+        Entity(ped).state.set(PLAYER_COPYABLE_ANIMATION_STATE_KEY, animation, true);
+
+        runner.finally(() => {
+            if (this.copyableAnimationRunnerId !== runner.id) {
+                return;
+            }
+
+            this.copyableAnimationRunnerId = null;
+            Entity(ped).state.set(PLAYER_COPYABLE_ANIMATION_STATE_KEY, null, true);
+        });
+    }
 
     public async walkToCoords(coords: Vector4, duration = 1000) {
         const playerPed = PlayerPedId();
@@ -51,6 +77,13 @@ export class AnimationService {
 
         if (!this.runningAnimations.has(id)) {
             const runner = this.animationFactory.createAnimation(animation, options);
+
+            this.publishCopyableAnimation(
+                { type: 'animation', animation },
+                runner,
+                options?.ped || PlayerPedId()
+            );
+
             this.runningAnimations.set(id, {
                 runner,
                 dictionary: animation.base.dictionary,
@@ -109,6 +142,14 @@ export class AnimationService {
             this.runningAnimations.get(id).runner.cancel(AnimationStopReason.Canceled);
         } else {
             const runner = this.animationFactory.createAnimation(animation, options);
+
+            this.publishCopyableAnimation(
+                { type: 'animation', animation },
+                runner,
+                options?.ped || PlayerPedId()
+            );
+
+
             this.runningAnimations.set(id, {
                 runner,
                 dictionary: animation.base.dictionary,
@@ -144,6 +185,13 @@ export class AnimationService {
             this.runningAnimations.get(id).runner.cancel(AnimationStopReason.Canceled);
         } else {
             const runner = this.animationFactory.createScenario(scenario, options);
+
+            this.publishCopyableAnimation(
+                { type: 'scenario', scenario },
+                runner,
+                options?.ped || PlayerPedId()
+            );
+
             this.runningAnimations.set(id, {
                 runner,
                 dictionary: null,
@@ -160,6 +208,13 @@ export class AnimationService {
         const id = scenario.name;
 
         const runner = this.animationFactory.createScenario(scenario, options);
+
+        this.publishCopyableAnimation(
+            { type: 'scenario', scenario },
+            runner,
+            options?.ped || PlayerPedId()
+        );
+
         this.runningAnimations.set(id, {
             runner,
             dictionary: null,
@@ -177,6 +232,13 @@ export class AnimationService {
         const id = animation.base.dictionary + animation.base.name;
 
         const runner = this.animationFactory.createAnimation(animation, options);
+
+        this.publishCopyableAnimation(
+            { type: 'animation', animation },
+            runner,
+            options?.ped || PlayerPedId()
+        );
+
         this.runningAnimations.set(id, {
             runner,
             dictionary: animation.base.dictionary,
@@ -186,6 +248,7 @@ export class AnimationService {
         runner.finally(() => {
             this.runningAnimations.delete(id);
         });
+
         return runner;
     }
 

--- a/resources/[soz]/soz-core/src/client/player/player.animation.provider.ts
+++ b/resources/[soz]/soz-core/src/client/player/player.animation.provider.ts
@@ -1,12 +1,20 @@
 import { DroneProvider } from '@private/client/vehicle/drone.provider';
 
 import { Command } from '../../core/decorators/command';
-import { OnEvent, OnNuiEvent } from '../../core/decorators/event';
+import { Once, OnceStep, OnEvent, OnNuiEvent } from '../../core/decorators/event';
 import { Inject } from '../../core/decorators/injectable';
 import { Provider } from '../../core/decorators/provider';
 import { Logger } from '../../core/logger';
 import { uuidv4 } from '../../core/utils';
-import { AnimationConfigItem, MoodConfigItem, WalkConfigBase, WalkConfigItem, Walking } from '../../shared/animation';
+import {
+    AnimationConfigItem,
+    CopyableAnimation,
+    MoodConfigItem,
+    PLAYER_COPYABLE_ANIMATION_STATE_KEY,
+    WalkConfigBase,
+    WalkConfigItem,
+    Walking,
+} from '../../shared/animation';
 import { ClientEvent, NuiEvent } from '../../shared/event';
 import { Shortcut } from '../../shared/nui/player';
 import { getRandomItem } from '../../shared/random';
@@ -17,6 +25,7 @@ import { Notifier } from '../notifier';
 import { InputService } from '../nui/input.service';
 import { NuiDispatch } from '../nui/nui.dispatch';
 import { ProgressService } from '../progress.service';
+import { TargetFactory } from '../target/target.factory';
 import { PlayerService } from './player.service';
 
 const ANIMATION_FAVORITE_PREFIX = 'animation:favorite:';
@@ -46,6 +55,100 @@ export class PlayerAnimationProvider {
 
     @Inject(DroneProvider)
     private droneProvider: DroneProvider;
+
+    @Inject(TargetFactory)
+private targetFactory: TargetFactory;
+
+@Once(OnceStep.PlayerLoaded)
+public registerCopyAnimationTarget() {
+    this.targetFactory.createForAllPlayer([
+        {
+            label: "Copier l'animation",
+            category: 'citizen',
+            canInteract: entity => this.isCopyableAnimationPlaying(entity),
+            action: entity => this.copyAnimation(entity),
+        },
+    ]);
+}
+
+private getCopyableAnimation(entity: number): CopyableAnimation | null {
+    const copyableAnimation = Entity(entity).state[
+        PLAYER_COPYABLE_ANIMATION_STATE_KEY
+    ] as CopyableAnimation;
+
+    if (
+        copyableAnimation?.type === 'animation' &&
+        typeof copyableAnimation.animation?.base?.dictionary === 'string' &&
+        typeof copyableAnimation.animation.base.name === 'string'
+    ) {
+        return copyableAnimation;
+    }
+
+    if (
+        copyableAnimation?.type === 'scenario' &&
+        typeof copyableAnimation.scenario?.name === 'string'
+    ) {
+        return copyableAnimation;
+    }
+
+    return null;
+}
+
+private isCopyableAnimationPlaying(entity: number): boolean {
+    const copyableAnimation = this.getCopyableAnimation(entity);
+
+    if (!copyableAnimation) {
+        return false;
+    }
+
+    if (copyableAnimation.type === 'scenario') {
+        return IsPedUsingScenario(entity, copyableAnimation.scenario.name);
+    }
+
+    const { dictionary, name } = copyableAnimation.animation.base;
+
+    return IsEntityPlayingAnim(entity, dictionary, name, 3);
+}
+
+private async copyAnimation(entity: number) {
+        if (!this.isCopyableAnimationPlaying(entity)) {
+        return;
+    }
+
+    const copyableAnimation = this.getCopyableAnimation(entity);
+
+    if (!copyableAnimation) {
+        return;
+    }
+
+    await this.animationService.stop();
+
+    if (copyableAnimation.type === 'scenario') {
+        this.animationService.playScenario({
+            ...copyableAnimation.scenario,
+            position: undefined,
+            shouldTeleport: false,
+        });
+
+        return;
+    }
+
+    const animation = copyableAnimation.animation;
+
+    this.animationService.playAnimation({
+        ...animation,
+        enter: animation.enter
+            ? { ...animation.enter, coords: undefined }
+            : undefined,
+        base: {
+            ...animation.base,
+            coords: undefined,
+        },
+        exit: animation.exit
+            ? { ...animation.exit, coords: undefined }
+            : undefined,
+    });
+}
 
     @Command('animation_stop', {
         description: "Stop l'animation en cours",

--- a/resources/[soz]/soz-core/src/shared/animation.ts
+++ b/resources/[soz]/soz-core/src/shared/animation.ts
@@ -75,6 +75,19 @@ export type Animation = {
     exit?: AnimationInfo;
 };
 
+export const PLAYER_COPYABLE_ANIMATION_STATE_KEY = 'soz:copyableAnimation';
+
+export type CopyableAnimation =
+    | {
+          type: 'animation';
+          animation: Animation;
+      }
+    | {
+          type: 'scenario';
+          scenario: Scenario;
+      };
+
+
 export type Scenario = {
     name: string;
     duration?: number;


### PR DESCRIPTION
This PR adds the ability to copy another player's active animation through the player target menu.

**## Changes**

- Added a replicated player state containing the currently active animation or scenario.
- Added a `Copy animation` interaction to the player target menu.
- Only displays the interaction when the targeted player is actively playing a copyable animation.
- Stops the local player's current animation before playing the copied one.
- Preserves the animation options and attached props.
- Removes absolute animation coordinates to prevent the local player from being teleported to the targeted player's position.
- Clears the replicated animation state when the animation stops.

**## Testing**

Tested locally with two players:

- The interaction is not displayed when the targeted player is idle.
- The interaction appears when the targeted player starts an animation.
- Selecting it stops the local player's previous animation and plays the targeted player's animation.
- Animations using attached props, such as the lighter animation, are copied correctly.
- The interaction disappears when the targeted player stops their animation.

_Video to display the feature : 
https://github.com/user-attachments/assets/007958ce-44fc-44a2-bf7a-324a051fcbca_
